### PR TITLE
Add additional parameters for folium layer

### DIFF
--- a/folium_pmtiles/vector.py
+++ b/folium_pmtiles/vector.py
@@ -32,8 +32,6 @@ class PMTilesVectorBaseMap(JSCSSMixin, Layer):
     ]
 
     def __init__(self, url, layer_name=None, options=None, **kwargs):
-
-        
         self.layer_name = layer_name if layer_name else "PMTilesVector"
 
         super().__init__(name=self.layer_name, **kwargs)

--- a/folium_pmtiles/vector.py
+++ b/folium_pmtiles/vector.py
@@ -31,10 +31,12 @@ class PMTilesVectorBaseMap(JSCSSMixin, Layer):
         )
     ]
 
-    def __init__(self, url, layer_name=None, options=None):
+    def __init__(self, url, layer_name=None, options=None, **kwargs):
+
+        
         self.layer_name = layer_name if layer_name else "PMTilesVector"
 
-        super().__init__(name=self.layer_name)
+        super().__init__(name=self.layer_name, **kwargs)
 
         self.url = url
         self._name = "PMTilesVector"

--- a/folium_pmtiles/vector.py
+++ b/folium_pmtiles/vector.py
@@ -83,10 +83,10 @@ class PMTilesMapLibreLayer(JSCSSMixin, Layer):
         ),
     ]
 
-    def __init__(self, url, layer_name=None, style=None):
+    def __init__(self, url, layer_name=None, style=None, **kwargs):
         self.layer_name = layer_name if layer_name else "PMTilesVector"
 
-        super().__init__(name=self.layer_name)
+        super().__init__(name=self.layer_name, **kwargs)
 
         self.url = url
         self._name = "PMTilesVector"


### PR DESCRIPTION
I am excited for find this package! Nice work. This PR adds `kwargs` to the `__init__` so that it can accept other folium layer paramters, such as `overlay`. Putting `overlay` in `options` has not effect. 

BTW, the PMTiles has a large gray background on the top of other layers. Can it be made transprant? 

```python
import folium
from folium_pmtiles.vector import PMTilesVectorBaseMap

m = folium.Map(location=[43.7798, 11.24148], zoom_start=12)
pmtiles_layer = PMTilesVectorBaseMap(
    "https://pmtiles.jtmiclat.me/protomaps(vector)ODbL_firenze.pmtiles",
    "PMtiles",
    options={
        "attribution": """<a href="https://protomaps.com">Protomaps</a> © <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>'"""
    },
    overlay=True,
)
m.add_child(pmtiles_layer)
folium.LayerControl().add_to(m)
m
```

![image](https://github.com/jtmiclat/folium-pmtiles/assets/5016453/c7527bdf-90ca-4aca-9ad2-3c06979a3d5b)
